### PR TITLE
Testing namespace and PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5"

--- a/tests/TraversTest.php
+++ b/tests/TraversTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Luur;
+namespace Luur\Tests;
 
+use Luur\Travers;
 use Luur\Exceptions\BranchNotFoundException;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +13,7 @@ class TraversTest extends TestCase
      */
     protected $tree;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- Since using the `PHPUnit:^7.5` version, it should let this package require `php-7.1` version at least.
- Adding the ` Luur\Tests;` for testing classes.
- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp()` method.